### PR TITLE
Update renderWebGL to prefer the more modern WebGL2

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -129,9 +129,9 @@ class RenderWebGL extends EventEmitter {
                 xrCompatible: true
             };
             return !!(
-                optCanvas.getContext('webgl', options) ||
+                optCanvas.getContext('webgl2', options) ||
                 optCanvas.getContext('experimental-webgl', options) ||
-                optCanvas.getContext('webgl2', options)
+                optCanvas.getContext('webgl', options)
             );
         } catch (e) {
             return false;
@@ -155,8 +155,8 @@ class RenderWebGL extends EventEmitter {
         // getWebGLContext = try WebGL 1.0 only
         // getContext = try WebGL 2.0 and if that doesn't work, try WebGL 1.0
         // getWebGLContext || getContext = try WebGL 1.0 and if that doesn't work, try WebGL 2.0
-        return twgl.getWebGLContext(canvas, contextAttribs) ||
-            twgl.getContext(canvas, contextAttribs);
+        return twgl.getContext(canvas, contextAttribs) ||
+            twgl.getWebGLContext(canvas, contextAttribs);
     }
 
     /**


### PR DESCRIPTION
### Resolves
None Just makes some features easier.

### Proposed Changes
Makes the renderer prefer webgl2 instead of webgl

### Reason for Changes
It would be very cool. And it would allow for pen+ to have proper GLES 3 syntax support

### Test Coverage
I just swapped some thingys
